### PR TITLE
Fix for deno v1.0.0-rc2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ install:
 	deno --version
 
 test:
-	deno run --reload --allow-env --allow-read ./test.ts
+	deno test --reload --allow-env --allow-read ./test.ts
 
 fmt:
 	deno fmt *

--- a/dotenv_test.ts
+++ b/dotenv_test.ts
@@ -1,12 +1,12 @@
 import { MissingEnvVarsError, parse, config } from "./dotenv.ts";
 import {
   assertThrows,
-  assertEquals
+  assertEquals,
 } from "https://deno.land/std/testing/asserts.ts";
 
-Deno.test(function parser() {
+Deno.test("parser", () => {
   const testDotenv = new TextDecoder("utf-8").decode(
-    Deno.readFileSync("./.env.test")
+    Deno.readFileSync("./.env.test"),
   );
   const config = parse(testDotenv);
   assertEquals(config.BASIC, "basic", "parses a basic variable");
@@ -16,17 +16,17 @@ Deno.test(function parser() {
   assertEquals(
     config.QUOTED_SINGLE,
     "single quoted",
-    "single quotes are escaped"
+    "single quotes are escaped",
   );
   assertEquals(
     config.QUOTED_DOUBLE,
     "double quoted",
-    "double quotes are escaped"
+    "double quotes are escaped",
   );
   assertEquals(
     config.MULTILINE,
     "hello\nworld",
-    "new lines are expanded in double quotes"
+    "new lines are expanded in double quotes",
   );
   assertEquals(config.JSON, '{"foo": "bar"}', "inner quotes are maintained");
   assertEquals(config.WHITESPACE, "whitespace", "values are trimmed");
@@ -34,12 +34,12 @@ Deno.test(function parser() {
   assertEquals(
     config.MULTILINE_SINGLE_QUOTE,
     "hello\\nworld",
-    "new lines are escaped in single quotes"
+    "new lines are escaped in single quotes",
   );
   assertEquals(config.EQUALS, "equ==als", "handles equals inside string");
 });
 
-Deno.test(function configure() {
+Deno.test("configure", () => {
   let conf = config();
   assertEquals(conf.GREETING, "hello world", "fetches .env by default");
 
@@ -48,42 +48,42 @@ Deno.test(function configure() {
 
   conf = config({ export: true });
   assertEquals(
-    Deno.env().GREETING,
+    Deno.env.get("GREETING"),
     "hello world",
-    "exports variables to env when requested"
+    "exports variables to env when requested",
   );
 });
 
-Deno.test(function configureSafe() {
+Deno.test("configureSafe", () => {
   // Default
   let conf = config({
-    safe: true
+    safe: true,
   });
   assertEquals(conf.GREETING, "hello world", "fetches .env by default");
 
   // Custom .env.example
   conf = config({
     safe: true,
-    example: "./.env.example.test"
+    example: "./.env.example.test",
   });
 
   assertEquals(
     conf.GREETING,
     "hello world",
-    "accepts a path to fetch env example from"
+    "accepts a path to fetch env example from",
   );
 
   // Custom .env and .env.example
   conf = config({
     path: "./.env.safe.test",
     safe: true,
-    example: "./.env.example.test"
+    example: "./.env.example.test",
   });
 
   assertEquals(
     conf.GREETING,
     "hello world",
-    "accepts paths to fetch env and env example from"
+    "accepts paths to fetch env and env example from",
   );
 
   // Throws if not all required vars are there
@@ -91,7 +91,7 @@ Deno.test(function configureSafe() {
     config({
       path: "./.env.safe.test",
       safe: true,
-      example: "./.env.example2.test"
+      example: "./.env.example2.test",
     });
   }, MissingEnvVarsError);
 
@@ -100,7 +100,7 @@ Deno.test(function configureSafe() {
     config({
       path: "./.env.safe.empty.test",
       safe: true,
-      example: "./.env.example2.test"
+      example: "./.env.example2.test",
     });
   }, MissingEnvVarsError);
 
@@ -109,35 +109,33 @@ Deno.test(function configureSafe() {
     path: "./.env.safe.empty.test",
     safe: true,
     example: "./.env.example2.test",
-    allowEmptyValues: true
+    allowEmptyValues: true,
   });
 
   // Does not throw if any of the required vars passed externaly
-  Deno.env().ANOTHER = "VAR";
-  config({
-    path: "./.env.safe.test",
-    safe: true,
-    example: "./.env.example2.test"
-  });
-
-  // Throws if any of the required vars passed externaly is empty
-  Deno.env().ANOTHER = "";
-  assertThrows(() => {
-    config({
-      path: "./.env.safe.test",
-      safe: true,
-      example: "./.env.example2.test"
-    });
-  });
-
-  // Does not throw if any of the required vars passed externaly is empty, *and* allowEmptyValues is present
-  Deno.env().ANOTHER = "";
+  Deno.env.set("ANOTHER", "VAR");
   config({
     path: "./.env.safe.test",
     safe: true,
     example: "./.env.example2.test",
-    allowEmptyValues: true
+  });
+
+  // Throws if any of the required vars passed externaly is empty
+  Deno.env.set("ANOTHER", "");
+  assertThrows(() => {
+    config({
+      path: "./.env.safe.test",
+      safe: true,
+      example: "./.env.example2.test",
+    });
+  });
+
+  // Does not throw if any of the required vars passed externaly is empty, *and* allowEmptyValues is present
+  Deno.env.set("ANOTHER", "");
+  config({
+    path: "./.env.safe.test",
+    safe: true,
+    example: "./.env.example2.test",
+    allowEmptyValues: true,
   });
 });
-
-await Deno.runTests();

--- a/load_test.ts
+++ b/load_test.ts
@@ -1,12 +1,10 @@
 import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
 import "./load.ts";
 
-Deno.test(function load() {
+Deno.test("load", () => {
   assertEquals(
-    Deno.env().GREETING,
+    Deno.env.get("GREETING"),
     "hello world",
-    "auto exports .env into env"
+    "auto exports .env into env",
   );
 });
-
-await Deno.runTests();

--- a/util.ts
+++ b/util.ts
@@ -12,5 +12,5 @@ export function compact(obj: any): object {
 }
 
 export function difference(arrA: string[], arrB: string[]): string[] {
-  return arrA.filter(a => arrB.indexOf(a) < 0);
+  return arrA.filter((a) => arrB.indexOf(a) < 0);
 }

--- a/util_test.ts
+++ b/util_test.ts
@@ -1,35 +1,33 @@
 import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
 import { compact, difference, trim } from "./util.ts";
 
-Deno.test(function compactTest() {
+Deno.test("compactTest", () => {
   const actual = compact({
     foo: true,
     bar: false,
     baz: null,
-    qux: "hi"
+    qux: "hi",
   });
   const expected = {
     foo: true,
-    qux: "hi"
+    qux: "hi",
   };
 
   assertEquals(actual, expected, "removes falsy values");
 });
 
-Deno.test(function trimTest() {
+Deno.test("trimTest", () => {
   const actual = trim(" hello world. \n\t ");
   const expected = "hello world.";
   assertEquals(actual, expected, "trims whitespace");
 });
 
-Deno.test(function differenceTest() {
+Deno.test("differenceTest", () => {
   const actual = difference(["a", "b", "c"], ["b", "c", "d"]);
   const expected = ["a"];
   assertEquals(
     actual,
     expected,
-    "returns an array of elements in list1 that are not in list2"
+    "returns an array of elements in list1 that are not in list2",
   );
 });
-
-await Deno.runTests();


### PR DESCRIPTION
- `Deno.env()` is replaced with `Deno.env.set('KEY', value)`, `Deno.env.get('KEY')` or `Deno.env.toObject()` where appropriate.
- `Deno.runTests` is removed -> make file is changed to call with deno test command.