### PR TITLE
Support spaces around equals

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -13,3 +13,5 @@ WHITESPACE='    whitespace   '
 MULTILINE_SINGLE_QUOTE='hello\nworld'
 EQUALS='equ==als'
 THE_ANSWER=42
+
+VAR_WITH_SPACE = 'var with space'

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ console.log(Deno.env.get('GREETING'));
 ```
 
 ```
-> deno --allow-env app.ts
+> deno --allow-env --allow-read app.ts
 hello world
 ```
 

--- a/mod.ts
+++ b/mod.ts
@@ -15,7 +15,7 @@ export interface ConfigOptions {
 export function parse(rawDotenv: string): DotenvConfig {
   return rawDotenv.split("\n").reduce((acc: any, line) => {
     if (!isVariableStart(line)) return acc;
-    let [key, ...vals] = line.split("=");
+    let [key, ...vals] = removeSpacesAroundEquals(line).split("=");
     let value = vals.join("=");
     if (/^"/.test(value)) {
       value = expandNewlines(value);
@@ -58,11 +58,15 @@ function parseFile(filepath: string) {
 }
 
 function isVariableStart(str: string): boolean {
-  return /^[a-zA-Z_]*=/.test(str);
+  return /^[a-zA-Z_ ]*=/.test(str);
 }
 
 function cleanQuotes(value: string = ""): string {
   return value.replace(/^['"]([\s\S]*)['"]$/gm, "$1");
+}
+
+function removeSpacesAroundEquals(str: string): string {
+  return str.replace(/( *= *)/, "=");
 }
 
 function expandNewlines(str: string): string {

--- a/mod_test.ts
+++ b/mod_test.ts
@@ -37,6 +37,12 @@ Deno.test("parser", () => {
     "new lines are escaped in single quotes",
   );
   assertEquals(config.EQUALS, "equ==als", "handles equals inside string");
+
+  assertEquals(
+    config.VAR_WITH_SPACE,
+    "var with space",
+    "variables defined with spaces are parsed",
+  );
 });
 
 Deno.test("configure", () => {


### PR DESCRIPTION
It's supported in npm `dotenv` so why not here. :)