### PR TITLE
fix: parse variables that contain numbers

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -15,3 +15,5 @@ EQUALS='equ==als'
 THE_ANSWER=42
 
 VAR_WITH_SPACE = 'var with space'
+
+V4R_W1TH_NUM8ER5='var with numbers'

--- a/mod.ts
+++ b/mod.ts
@@ -58,7 +58,7 @@ function parseFile(filepath: string) {
 }
 
 function isVariableStart(str: string): boolean {
-  return /^[a-zA-Z_ ]*=/.test(str);
+  return /^[a-zA-Z_][a-zA-Z_0-9 ]*=/.test(str);
 }
 
 function cleanQuotes(value: string = ""): string {

--- a/mod_test.ts
+++ b/mod_test.ts
@@ -43,6 +43,12 @@ Deno.test("parser", () => {
     "var with space",
     "variables defined with spaces are parsed",
   );
+
+  assertEquals(
+    config.V4R_W1TH_NUM8ER5,
+    "var with numbers",
+    "accepts variables containing number",
+  );
 });
 
 Deno.test("configure", () => {


### PR DESCRIPTION
https://stackoverflow.com/questions/2821043/allowed-characters-in-linux-environment-variable-names

Closes https://github.com/pietvanzoen/deno-dotenv/issues/26