### PR TITLE
remove spaces around environment variables with export option

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -46,7 +46,7 @@ export function config(options: ConfigOptions = {}): DotenvConfig {
 
   if (o.export) {
     for (let key in conf) {
-      Deno.env.set(key, conf[key]);
+      Deno.env.set(key.trim(), conf[key].trim());
     }
   }
 


### PR DESCRIPTION
With this improvement, avoid the spaces by mistake of the .env file example:

file .env:
/ * A space is left by mistake in front of the constants * /
 CONSTANT = value
 CONSTANT2=value

file app.ts:
import {config} from 'https://deno.land/x/dotenv/mod.ts';
await config ({export: true});

console.log (Deno.env.get ('CONSTANT'); // Now this doesn't get error