### PR TITLE
Patch: Explicit Permission

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -28,10 +28,10 @@ export function parse(rawDotenv: string): DotenvConfig {
 export function config(options: ConfigOptions = {}): DotenvConfig {
   const o: Required<ConfigOptions> = Object.assign(
     {
-      path: `${Deno.cwd()}/.env`,
+      path: `.env`,
       export: false,
       safe: false,
-      example: `${Deno.cwd()}/.env.example`,
+      example: `.env.example`,
       allowEmptyValues: false,
     },
     options,


### PR DESCRIPTION
Removal of Deno.cwd() is required when explicit --allow-read=.env permission is used.
Else blanket --allow-read=. is required to accommodate for inclusion of Deno.cwd().

This may be undesirable for some developers that wish or are required to institute the policy of least access when declaring permissions.

It is better to use relative paths in this instance until better permission settings are implemented within Deno.

Alternatively, a flag could be created to allow for either solution if desired but is not implemented in this pull request.