### PR TITLE
fix: avoid overwriting existing environment variables on export

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 GREETING=hello world
+DO_NOT_OVERRIDE=overridden

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ The parsing engine currently supports the following rules:
 - empty values become empty strings (`EMPTY=` becomes `{EMPTY: ''}`)
 - single and double quoted values are escaped (`SINGLE_QUOTE='quoted'` becomes `{SINGLE_QUOTE: "quoted"}`)
 - new lines are expanded if in double quotes (`MULTILINE="new\nline"` becomes
+- Variables that already exist in the environment are not overridden with `export: true`
 
 ```
 {MULTILINE: 'new

--- a/mod.ts
+++ b/mod.ts
@@ -57,6 +57,7 @@ export function config(options: ConfigOptions = {}): DotenvConfig {
 
   if (o.export) {
     for (let key in conf) {
+      if (Deno.env.get(key) !== undefined) continue;
       Deno.env.set(key, conf[key]);
     }
   }

--- a/mod_test.ts
+++ b/mod_test.ts
@@ -80,6 +80,14 @@ Deno.test("configure", () => {
     "exports variables to env when requested",
   );
 
+  Deno.env.set("DO_NOT_OVERRIDE", "Hello there");
+  conf = config({ export: true });
+  assertEquals(
+    Deno.env.get("DO_NOT_OVERRIDE"),
+    "Hello there",
+    "does not export .env value if environment variable is already set",
+  );
+
   assertEquals(
     config(
       {


### PR DESCRIPTION
BREAKING CHANGE: This was the intended behaviour but overlooked. Setting
environment variables outside of your dotenv should override values in
your dotenv.

Closes: https://github.com/pietvanzoen/deno-dotenv/issues/39