### PR TITLE
fix: Allow 'safe' requirement to be met by 'defaults'

### DIFF
--- a/.env.example3.test
+++ b/.env.example3.test
@@ -1,0 +1,1 @@
+DEFAULT1=

--- a/mod.ts
+++ b/mod.ts
@@ -47,11 +47,6 @@ export function config(options: ConfigOptions = {}): DotenvConfig {
 
   const conf = parseFile(o.path);
 
-  if (o.safe) {
-    const confExample = parseFile(o.example);
-    assertSafe(conf, confExample, o.allowEmptyValues);
-  }
-
   if (o.defaults) {
     const confDefaults = parseFile(o.defaults);
     for (const key in confDefaults) {
@@ -59,6 +54,11 @@ export function config(options: ConfigOptions = {}): DotenvConfig {
         conf[key] = confDefaults[key];
       }
     }
+  }
+
+  if (o.safe) {
+    const confExample = parseFile(o.example);
+    assertSafe(conf, confExample, o.allowEmptyValues);
   }
 
   if (o.export) {

--- a/mod_test.ts
+++ b/mod_test.ts
@@ -196,6 +196,14 @@ Deno.test("configureSafe", () => {
     });
   }, MissingEnvVarsError);
 
+  // Does not throw if required vars are provided by example
+  config({
+    path: "./.env.safe.empty.test",
+    safe: true,
+    example: "./.env.example3.test",
+    defaults: "./.env.defaults",
+  });
+
   // Does not throw if any of the required vars is empty, *and* allowEmptyValues is present
   config({
     path: "./.env.safe.empty.test",


### PR DESCRIPTION
This PR fixes a bug where the `safe: true` check is performed before pulling in values from the `defaults` file.