### PR TITLE
feat: deno deploy compatibility

### DIFF
--- a/load.ts
+++ b/load.ts
@@ -1,3 +1,3 @@
-import { config } from "./mod.ts";
+import { configAsync } from "./mod.ts";
 
-config({ export: true });
+await configAsync({ export: true });

--- a/mod_test.ts
+++ b/mod_test.ts
@@ -1,5 +1,5 @@
-import { assertEquals, assertThrows } from "./test_deps.ts";
-import { config, MissingEnvVarsError, parse } from "./mod.ts";
+import { assertEquals, assertRejects, assertThrows } from "./test_deps.ts";
+import { config, configAsync, MissingEnvVarsError, parse } from "./mod.ts";
 
 Deno.test("parser", () => {
   const testDotenv = new TextDecoder("utf-8").decode(
@@ -233,6 +233,142 @@ Deno.test("configureSafe", () => {
   // Does not throw if any of the required vars passed externaly is empty, *and* allowEmptyValues is present
   Deno.env.set("ANOTHER", "");
   config({
+    path: "./.env.safe.test",
+    safe: true,
+    example: "./.env.example2.test",
+    allowEmptyValues: true,
+  });
+});
+
+Deno.test("configure async", async () => {
+  let conf = await configAsync();
+  assertEquals(conf.GREETING, "hello world", "fetches .env by default");
+
+  assertEquals(conf.DEFAULT1, "Some Default", "default value loaded");
+
+  conf = await configAsync({ path: "./.env.test" });
+  assertEquals(conf.BASIC, "basic", "accepts a path to fetch env from");
+
+  conf = await configAsync({ export: true });
+  assertEquals(
+    Deno.env.get("GREETING"),
+    "hello world",
+    "exports variables to env when requested",
+  );
+
+  Deno.env.set("DO_NOT_OVERRIDE", "Hello there");
+  conf = await configAsync({ export: true });
+  assertEquals(
+    Deno.env.get("DO_NOT_OVERRIDE"),
+    "Hello there",
+    "does not export .env value if environment variable is already set",
+  );
+
+  assertEquals(
+    await configAsync(
+      {
+        path: "./.some.non.existent.env",
+        defaults: "./.some.non.existent.env",
+      },
+    ),
+    {},
+    "returns empty object if file doesn't exist",
+  );
+
+  assertEquals(
+    await configAsync({ path: "./.some.non.existent.env" }),
+    { DEFAULT1: "Some Default" },
+    "returns with defaults if file doesn't exist",
+  );
+});
+
+Deno.test("configureSafe async", async () => {
+  // Default
+  let conf = await configAsync({
+    safe: true,
+  });
+  assertEquals(conf.GREETING, "hello world", "fetches .env by default");
+
+  // Custom .env.example
+  conf = await configAsync({
+    safe: true,
+    example: "./.env.example.test",
+  });
+
+  assertEquals(
+    conf.GREETING,
+    "hello world",
+    "accepts a path to fetch env example from",
+  );
+
+  // Custom .env and .env.example
+  conf = await configAsync({
+    path: "./.env.safe.test",
+    safe: true,
+    example: "./.env.example.test",
+  });
+
+  assertEquals(
+    conf.GREETING,
+    "hello world",
+    "accepts paths to fetch env and env example from",
+  );
+
+  // Throws if not all required vars are there
+  assertRejects(async () => {
+    await configAsync({
+      path: "./.env.safe.test",
+      safe: true,
+      example: "./.env.example2.test",
+    });
+  }, MissingEnvVarsError);
+
+  // Throws if any of the required vars is empty
+  assertRejects(async () => {
+    await configAsync({
+      path: "./.env.safe.empty.test",
+      safe: true,
+      example: "./.env.example2.test",
+    });
+  }, MissingEnvVarsError);
+
+  // Does not throw if required vars are provided by example
+  await configAsync({
+    path: "./.env.safe.empty.test",
+    safe: true,
+    example: "./.env.example3.test",
+    defaults: "./.env.defaults",
+  });
+
+  // Does not throw if any of the required vars is empty, *and* allowEmptyValues is present
+  await configAsync({
+    path: "./.env.safe.empty.test",
+    safe: true,
+    example: "./.env.example2.test",
+    allowEmptyValues: true,
+  });
+
+  // Does not throw if any of the required vars passed externaly
+  Deno.env.set("ANOTHER", "VAR");
+  await configAsync({
+    path: "./.env.safe.test",
+    safe: true,
+    example: "./.env.example2.test",
+  });
+
+  // Throws if any of the required vars passed externaly is empty
+  Deno.env.set("ANOTHER", "");
+  assertRejects(async () => {
+    await configAsync({
+      path: "./.env.safe.test",
+      safe: true,
+      example: "./.env.example2.test",
+    });
+  });
+
+  // Does not throw if any of the required vars passed externaly is empty, *and* allowEmptyValues is present
+  Deno.env.set("ANOTHER", "");
+  await configAsync({
     path: "./.env.safe.test",
     safe: true,
     example: "./.env.example2.test",

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -1,4 +1,5 @@
 export {
   assertEquals,
+  assertRejects,
   assertThrows,
-} from "https://deno.land/std@0.81.0/testing/asserts.ts";
+} from "https://deno.land/std@0.112.0/testing/asserts.ts";


### PR DESCRIPTION
For now, importing this module from deno deploy gives the following error:

![image](https://user-images.githubusercontent.com/40050810/138596897-20747381-ebeb-49d9-a81c-6845cbf41ad2.png)


In this PR, create an asynchronous version of  `config()` that uses `Deno.readFile` instead of `Deno.readFileSync` to make `load.ts` compatible of deploy.

closes #54 